### PR TITLE
wrong checking NULL read only variable

### DIFF
--- a/c_dump.c
+++ b/c_dump.c
@@ -458,9 +458,7 @@ makeAccept(FILE *fh, ParamDef *def, int i) {
 						break;
 					case	stringType:
 						if (def->flags & PARAMDEF_RDONLY) {
-							fputs("\t\tif (check_rdonly && ( (opt->paramValue.scalarval == NULL && ", fh);
-							dumpStructFullPath(fh, "c", "i", def, 1, 0, 1);
-							fputs(" == NULL) || confetti_strcmp(opt->paramValue.scalarval, ", fh);
+							fputs("\t\tif (check_rdonly && ( confetti_strcmp(opt->paramValue.scalarval, ", fh);
 							dumpStructFullPath(fh, "c", "i", def, 1, 0, 1);
 							fputs(") != 0))\n\t\t\treturn CNF_RDONLY;\n", fh);
 						}

--- a/example/example.c
+++ b/example/example.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <string.h>
 
 #include <prscfg.h>
 #include <my_product_cfg.h>
@@ -22,6 +23,8 @@ main(int argc, char* argv[]) {
 	my_product	cfg, dup_cfg;
 	my_product_iterator_t	*i;
 	char		*key, *value;
+
+        memset(&dup_cfg, 0, sizeof(dup_cfg));
 
 	fill_default_my_product(&cfg);
 

--- a/example/example.cfgtmpl
+++ b/example/example.cfgtmpl
@@ -83,3 +83,5 @@ array_with_required_structs_with_structs = [
 
 flsb = false
 flst = true
+
+ro_empty_str = NULL, ro


### PR DESCRIPTION
current version failed to check read only variables with NULL default if they exist in config

after adding variable to example/example.cfgtmpl:
ro_empty_str = NULL, ro

example failed to check read only variable in config, run as: 
./example ./my_product.cfg
```
Could not accept read only 'ro_empty_str' option
==========Accepted: 30; Skipped: 1; Optional: 0===========
```

no difference is expected when checking the same file.

works as intended after fixing:
```
==========Accepted: 31; Skipped: 0; Optional: 0===========
```
